### PR TITLE
Fix: Fixing broken url on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ The course is intended for any and all individuals interested in harnessing data
 Our teachers
 -----
 
-[Delta Teaching Fellows](http://www.deltanalytics.org/delta-teaching-fellows.html) are all data professionals working in the San Francisco Bay Area. All of our time is donated for free to build out a curriculum that makes machine learning tools and knowledge more accessible to communities around the world. You can learn more about our team [here](http://www.deltanalytics.org/delta-teaching-fellows.html).
+[Delta Teaching Fellows](http://www.deltanalytics.org/teaching-fellows.html) are all data professionals working in the San Francisco Bay Area. All of our time is donated for free to build out a curriculum that makes machine learning tools and knowledge more accessible to communities around the world. You can learn more about our team [here](http://www.deltanalytics.org/teaching-fellows.html).


### PR DESCRIPTION
Fixing the broken URL on the README file that is supposed to connect to the website of Delta Teaching fellows.
Updating the link to this current link (http://www.deltanalytics.org/teaching-fellows.html)